### PR TITLE
add rule ember-test-helpers-wait

### DIFF
--- a/docs/rules/ember-test-helpers-wait.md
+++ b/docs/rules/ember-test-helpers-wait.md
@@ -1,0 +1,22 @@
+# Deprecated 'wait' ember test helper
+
+## Rule Details
+
+The 'wait' function from the library 'ember-test-helpers/wait' is outdated.
+We should now use "import { settled } from \'@ember/test-helpers\';"
+
+Examples of **incorrect** code for this rule:
+
+```js
+import wait from 'ember-test-helpers/wait';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { wait } from 'ember-test-helpers/wait';
+```
+
+```js
+import wait from 'something/else/entirely';
+```

--- a/lib/rules/ember-test-helpers-wait.js
+++ b/lib/rules/ember-test-helpers-wait.js
@@ -1,0 +1,48 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const looksLike = require('../helpers/looks-like.js');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'catches deprecated "wait" functions imported from "ember-test-helpers/wait"',
+      recommended: true
+    },
+    schema: [
+      // fill in your schema
+    ]
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const isMatch = looksLike(node, {
+          source: {
+            type: 'Literal',
+            value: 'ember-test-helpers/wait'
+          },
+          specifiers(args) {
+            return !!args.find((specifier) =>
+              looksLike(specifier, {
+                type: 'ImportDefaultSpecifier'
+              })
+            );
+          }
+        });
+
+        if (!isMatch) {
+          return;
+        }
+
+        context.report(
+          node,
+          'The wait function is deprecated.  Please use "import { settled } from \'@ember/test-helpers\';"'
+        );
+      }
+    };
+  }
+};

--- a/tests/lib/rules/ember-test-helpers-wait.js
+++ b/tests/lib/rules/ember-test-helpers-wait.js
@@ -1,0 +1,34 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/ember-test-helpers-wait"),
+  RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: "module"
+  }
+});
+
+var ruleTester = new RuleTester();
+ruleTester.run("ember-test-helpers-wait", rule, {
+  valid: [
+    "import { wait } from 'ember-test-helpers/wait'",
+    "import wait from 'something/else/entirely'"
+  ],
+
+  invalid: [
+    {
+      code: "import wait from 'ember-test-helpers/wait'",
+      errors: ['The wait function is deprecated.  Please use "import { settled } from \'@ember/test-helpers\';"']
+    }
+  ]
+});


### PR DESCRIPTION
# Deprecated 'wait' ember test helper

# Summary:

The 'wait' function from the library 'ember-test-helpers/wait' is outdated.
We should now use:

```js
import { settled } from '@ember/test-helpers'
```

Adding this rule does **NOT** mean that the rule is automatically turned on in any app that uses the plugin.  Any app that uses this lint plugin must explicitly turn on the rule in order for it to go into effect.

Here's an interactive page where you can look at the abstract syntax tree:
https://astexplorer.net/#/gist/a87afd35cb50bebc9de9048ec39abeb7/00272c8bb558aeadca5eb2a5191bff74af7de8b0

# Test the rule on your own Ember app:

Make the following changes to your `eslintrc.js` and `package.json` files, then run either `npm install` or `yarn install`.  Start up the app and see what warnings if any are raised.

```diff
diff --git a/.eslintrc.js b/.eslintrc.js
index 350df8c47f..e99cca7b1b 100644
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'chirp'
   ],
   rules: {
+    "chirp/ember-test-helpers-wait": "warn",
     "chirp/multiple-awaited-new-promises": "error",
     "chirp/prohibit-this-dot-dollar": "error",
     "chirp/prohibit-dot-only": "error",
diff --git a/package.json b/package.json
index fbf0206902..50d732eeed 100644
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint": "^3.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-chirp": "git+ssh://git@github.com/IoraHealth/eslint-plugin-chirp-test-rules#v1.4.1",
+    "eslint-plugin-chirp": "git+ssh://git@github.com/IoraHealth/eslint-plugin-chirp-test-rules#ed9b4a55d8d4b41d12902426ea1e07cb20dab905",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-prettier": "^2.6.0",
```

Examples of **incorrect** code for this rule:

```js
import wait from 'ember-test-helpers/wait';
```

Examples of **correct** code for this rule:

```js
import { wait } from 'ember-test-helpers/wait';
```

```js
import wait from 'something/else/entirely';
```